### PR TITLE
Fix error handling in MCP server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    restart: always
 
   mcp-server:
     container_name: mcp-server
@@ -39,6 +40,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    restart: on-failure
+    restart_policy:
+      condition: on-failure
+      delay: 10s
 
   tester:
     image: node:23

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       MARIADB_PASS: test_password
       MARIADB_DB: test_db
       LOG_LEVEL: debug
-    restart: always
     entrypoint: npm exec mcp-proxy
     command: node /app/dist/index.js
     ports:
@@ -49,4 +48,3 @@ services:
     depends_on:
       mcp-server:
         condition: service_healthy
-

--- a/index.ts
+++ b/index.ts
@@ -300,5 +300,6 @@ circuitBreaker.on('halfOpen', () => logger.info('Circuit breaker half-open'));
 circuitBreaker.on('close', () => logger.info('Circuit breaker closed'));
 
 async function executeWithCircuitBreaker<T>(sql: string, params: any[] = []): Promise<T> {
-  return circuitBreaker.fire(sql, params);
+  const result = await circuitBreaker.fire(sql, params);
+  return result as T;
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.0.1",
+    "@types/opossum": "^8.1.8",
     "mariadb": "^3.2.3",
+    "opossum": "^8.4.0",
     "winston": "^3.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "prepare": "yarn compile && yarn build",
     "compile": "tsc",
-    "build": "shx chmod +x dist/*.js"
+    "build": "shx chmod +x dist/*.js",
+    "test": "docker-compose up --wait-timeout 60 --exit-code-from tester"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oleander/mcp-server-mariadb",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "MCP server for interacting with MariaDB databases based on Node",
   "license": "MIT",
   "author": "Ben Borla (https://github.com/benborla)",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "yarn compile && yarn build",
     "compile": "tsc",
     "build": "shx chmod +x dist/*.js",
-    "test": "docker-compose up --wait-timeout 60 --exit-code-from tester"
+    "test": "docker-compose up --wait-timeout 60 --force-recreate --exit-code-from tester"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,6 +101,13 @@
   resolved "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz"
   integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
 
+"@types/node@*", "@types/node@^22.5.4":
+  version "22.13.5"
+  resolved "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz"
+  integrity sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==
+  dependencies:
+    undici-types "~6.20.0"
+
 "@types/node@^20.10.0":
   version "20.17.19"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.17.19.tgz"
@@ -108,12 +115,12 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^22.5.4":
-  version "22.13.5"
-  resolved "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz"
-  integrity sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==
+"@types/opossum@^8.1.8":
+  version "8.1.8"
+  resolved "https://registry.yarnpkg.com/@types/opossum/-/opossum-8.1.8.tgz#79f138118d699348f80bbe4b4285995563bed8fe"
+  integrity sha512-FTpWfHcpMgdLIdaTpL1D/nTlIH03T62RIQfzmwdEDAndYJwHDdUTkBvgXhaVp/zN74woiWEyb6DSNuZHPt1gmA==
   dependencies:
-    undici-types "~6.20.0"
+    "@types/node" "*"
 
 "@types/triple-beam@^1.3.2":
   version "1.3.5"
@@ -577,6 +584,11 @@ one-time@^1.0.0:
   integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
   dependencies:
     fn.name "1.x.x"
+
+opossum@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/opossum/-/opossum-8.4.0.tgz#d4f5a3a326ed841e9e5288148886d94048bacc30"
+  integrity sha512-YYamqKu48bZCSTJKSWLLO4SSk8tKN2Gg2z1sJZVzHJYVObMO/xQpIzAh6re9HCMHRdB1dJvBjJH18DW7xYOicg==
 
 parse-ms@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Add error handling and circuit breaker to prevent crashes on MCP errors.

* **Error Handling**:
  - Add global handler for unhandled promise rejections in `index.ts` to log the error and exit with code 1.
  - Add global handler for uncaught exceptions in `index.ts` to log the error and exit with code 1.
  - Update `runServer` function in `index.ts` to catch errors and exit with code 1 if an error occurs during server startup.

* **Circuit Breaker**:
  - Import `opossum` library in `index.ts` and implement a circuit breaker pattern.
  - Configure the circuit breaker with appropriate settings for failure thresholds, timeouts, and state transitions.
  - Add detailed error logging for debugging purposes.

* **Docker Configuration**:
  - Remove the `restart: always` directive from `docker-compose.yml` for the `mcp-server` service to prevent automatic restarts on failure.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/oleander/mcp-server-mariadb/pull/5?shareId=28a3b45a-76df-44f5-bee1-b5c991bc6247).